### PR TITLE
fix file paths in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ npm install angularjs-color-picker --save
 ```html
     <link rel="stylesheet" href="bower_components/angularjs-color-picker/angularjs-color-picker.min.css" />
 
-    <script src="bower_components/tinycolor/tinycolor"></script>
-    <script src="bower_components/angularjs-color-picker/angularjs-color-picker.min.js"></script>
+    <script src="bower_components/tinycolor/dist/tinycolor-min.js"></script>
+    <script src="bower_components/angular-color-picker/angularjs-color-picker.min.js"></script>
 ```
 
 


### PR DESCRIPTION
Bower installs the package to angular-color-picker folder, not angularjs-color-picker, so fixed file path.
Also fixed file path for tinycolor (and used minified version). 