### PR TITLE
Bug #70 Fix for element wrapping

### DIFF
--- a/lib/styles/angularjs-color-picker.less
+++ b/lib/styles/angularjs-color-picker.less
@@ -184,7 +184,7 @@
 
 
     &.color-picker-swatch-only {
-        width: 35px;
+        width: auto;
 
         .color-picker-input {
             padding-left: 33px;
@@ -193,6 +193,7 @@
         }
 
         .input-group {
+            width: 35px;
             .input-group-addon {
                 width: 35px;
                 height: 100%;


### PR DESCRIPTION
Hue and opacity stripes were wrapped when using swatch only option
which cause layout breaking. The reason of wrapping was that, the container for picker elements was to narrow (set to 35px). The input group should be fixed size instead the container.