### PR TITLE
Explicitly specify that saturation and lightness are percentages. If …

### DIFF
--- a/src/scripts/controller.js
+++ b/src/scripts/controller.js
@@ -512,9 +512,9 @@ export default class AngularColorPickerController {
         var color;
 
         if (this.options.round) {
-            color = tinycolor({h: this.hue, s: this.saturation, l: this.lightness});
+            color = tinycolor({h: this.hue, s: `${this.saturation}%`, l: `${this.lightness}%`});
         } else {
-            color = tinycolor({h: this.hue, s: this.saturation, v: this.lightness});
+            color = tinycolor({h: this.hue, s: `${this.saturation}%`, v: `${this.lightness}%`});
         }
 
         if (this.options.alpha) {


### PR DESCRIPTION
…not, tinycolor tries to guess if a value is a percentage and sometimes ends up guessing wrong.

If you look at documentation for [tinycolor](http://bgrins.github.io/TinyColor/docs/tinycolor.html), you can look at inputToRGB() method.  For saturation and lightness, it calls convertToPercentage() method, and this method looks like this:

```
function convertToPercentage(n) {
    if (n <= 1) {
        n = (n * 100) + "%";
    }

    return n;
}
```

So, if we have saturation and lightness values of a very low percentage like 0.5 (i.e. half a percent), it thinks that this is not a percentage and multiplies by 100.

This pull request fixes #140 .