### PR TITLE
Options format property value handling fix

### DIFF
--- a/src/scripts/controller.js
+++ b/src/scripts/controller.js
@@ -546,7 +546,7 @@ export default class AngularColorPickerController {
         this.opacityPosUpdate();
 
         if (this.updateModel) {
-            switch (this.options.format) {
+            switch (this.options.format.toLowerCase()) {
                 case 'rgb':
                     this.ngModel = color.toRgbString();
                     break;


### PR DESCRIPTION
The color format option in current release, due to README.md, has invalid letter case. This change keep in mind compatibility with older versions.