### PR TITLE
Fix test which broke in v3.3.0 because of hex value formatting.

### DIFF
--- a/test/e2e/restrict-to-format.protractor.js
+++ b/test/e2e/restrict-to-format.protractor.js
@@ -8,7 +8,7 @@ describe('Options: ', () => {
         });
 
         it('Should allow any format by default', () => {
-            Page.format_field.$('[label="HEX"]').click();
+            Page.format_field.$('[label="HEXString"]').click();
             Page.input_field.clear().sendKeys('red');
             Page.blurColorPicker();
             Page.openColorPicker();
@@ -18,7 +18,7 @@ describe('Options: ', () => {
         it('Should only allow selected format', () => {
             Page.restrict_to_format_field.$('[label="Yes"]').click();
 
-            Page.format_field.$('[label="HEX"]').click();
+            Page.format_field.$('[label="HEXString"]').click();
             Page.input_field.clear().sendKeys('green');
             Page.blurColorPicker();
             Page.openColorPicker();
@@ -29,7 +29,7 @@ describe('Options: ', () => {
         it('Should allow any format again', () => {
             Page.restrict_to_format_field.$('[label="No"]').click();
 
-            Page.format_field.$('[label="HEX"]').click();
+            Page.format_field.$('[label="HEXString"]').click();
             Page.input_field.clear().sendKeys('blue');
             Page.blurColorPicker();
             Page.openColorPicker();

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -1,7 +1,7 @@
 angular
     .module('app', ['color.picker'])
     .controller('AppCtrl', function($scope) {
-        $scope.formatOptions = [{label: 'HSL', value: 'hsl'}, {label: 'HSV', value: 'hsv'}, {label: 'RGB', value: 'rgb'}, {label: 'HEX', value: 'hex'}, {label: 'HEX8', value: 'hex8'}, {label: 'Raw', value: 'raw'}];
+        $scope.formatOptions = [{label: 'HSL', value: 'hsl'}, {label: 'HSV', value: 'hsv'}, {label: 'RGB', value: 'rgb'}, {label: 'HEX', value: 'hex'}, {label: 'HEXString', value: 'hexstring'}, {label: 'HEX8', value: 'hex8'}, {label: 'Raw', value: 'raw'}];
         $scope.boolOptions = [{label: 'Yes', value: true}, {label: 'No', value: false}];
         $scope.swatchPosOptions = [{label: 'Left', value: 'left'}, {label: 'Right', value: 'right'}];
         $scope.posOptions = [{label: 'Bottom Left', value: 'bottom left'}, {label: 'Top Left', value: 'top left'}, {label: 'Bottom Right', value: 'bottom right'}, {label: 'Top Right', value: 'top right'}];


### PR DESCRIPTION
Previously the test was failing saying `Expected '0000FF' to equal '#0000FF'.`

Seems to have been a regression from https://github.com/ruhley/angular-color-picker/commit/269db7ac48624e744ab3d77ddfc9e94be705eb43

Ps. It would be nice to have travis-ci going. I see some work has been done to try to get it to work. I also had a crack at it, but couldnt figure it out. ¯\\_(ツ)_/¯