### PR TITLE
Add preserveInputFormat option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v3.4.2
+
+#### Breaking Changes
+  * None
+
+#### New Features
+  * Add preserveInputFormat option to control whether or not a valid input color of a different format should change to the configured format. For a visual explanation see https://github.com/ruhley/angular-color-picker/pull/164
+
 ## v3.4.1
 
 #### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ $scope.options = {
     name: undefined,
     // validation
     restrictToFormat: [false, true],
+    preserveInputFormat: [false, true],
     allowEmpty: [false, true],
     // color
     format: ['hsl', 'hsv', 'rgb', 'hex', 'hexString', 'hex8', 'hex8String', 'raw'],

--- a/src/scripts/controller.js
+++ b/src/scripts/controller.js
@@ -193,6 +193,7 @@ export default class AngularColorPickerController {
                 'AngularColorPickerController.options.case',
                 'AngularColorPickerController.options.round',
                 'AngularColorPickerController.options.restrictToFormat',
+                'AngularColorPickerController.options.preserveInputFormat',
                 'AngularColorPickerController.options.allowEmpty',
                 'AngularColorPickerController.options.horizontal'
             ],
@@ -545,7 +546,14 @@ export default class AngularColorPickerController {
         this.updateAlphaBackground(color);
         this.opacityPosUpdate();
 
-        if (this.updateModel) {
+        function inputColorEquals() {
+            var tcOfModel = tinycolor(this.ngModel);
+            return tcOfModel.toHsvString() === color.toHsvString();
+        }
+
+        var skipUpdate = this.options.preserveInputFormat && inputColorEquals();
+
+        if (this.updateModel && !skipUpdate) {
             switch (this.options.format.toLowerCase()) {
                 case 'rgb':
                     this.ngModel = color.toRgbString();

--- a/src/scripts/options-service.js
+++ b/src/scripts/options-service.js
@@ -10,6 +10,7 @@ export default class AngularColorPickerOptions {
             inputClass: '',
             // validation
             restrictToFormat: false,
+            preserveInputFormat: false,
             allowEmpty: false,
             // color
             format: 'hsl',

--- a/test/e2e/preserve-input-format.protractor.js
+++ b/test/e2e/preserve-input-format.protractor.js
@@ -1,0 +1,30 @@
+var Page = require('../page-object.js');
+
+describe('Options: ', () => {
+	describe('Preserve Input Format: ', () => {
+        beforeAll(() => {
+            Page.openPage();
+            Page.waitTillPageLoaded();
+        });
+
+        it('Should not preserve input format by default', () => {
+            Page.format_field.$('[label="HEXString"]').click();
+            Page.input_field.clear().sendKeys('red');
+            Page.blurColorPicker();
+            // value is still what the user typed in.
+            expect(Page.input_field.getAttribute('value')).toEqual('red');
+            // value suddenly changes when re-opening the color picker.
+            Page.openColorPicker();
+            expect(Page.input_field.getAttribute('value')).toEqual('#FF0000');
+        });
+
+        it('Should preserve input format', () => {
+            Page.format_field.$('[label="HEXString"]').click();
+            Page.preserve_input_format_field.$('[label="Yes"]').click();
+            Page.input_field.clear().sendKeys('red');
+            Page.blurColorPicker();
+            Page.openColorPicker();
+            expect(Page.input_field.getAttribute('value')).toEqual('red');
+        });
+    });
+});

--- a/test/page-object.js
+++ b/test/page-object.js
@@ -13,6 +13,7 @@ class Page {
 
         // validation fields
         this.restrict_to_format_field = element(by.model('options.restrictToFormat'));
+        this.preserve_input_format_field = element(by.model('options.preserveInputFormat'));
         this.allow_empty_field = element(by.model('options.allowEmpty'));
 
         // color fields

--- a/test/test.html
+++ b/test/test.html
@@ -96,6 +96,11 @@
                 </div>
 
                 <div class="row">
+                    <label class="control-label">Preserve Input Format (preserveInputFormat) - whether or not a valid input color of a different format should change to the configured format</label>
+                    <select ng-model="options.preserveInputFormat" class="form-control" ng-options="option.value as option.label for option in boolOptions"></select>
+                </div>
+
+                <div class="row">
                     <label class="control-label">Allow Empty (allowEmpty) - whether or not to allow empty values as valid</label>
                     <select ng-model="options.allowEmpty" class="form-control" ng-options="option.value as option.label for option in boolOptions"></select>
                 </div>


### PR DESCRIPTION
Add preserveInputFormat option to control whether or not a valid input color of a different format should change to the configured format. I think this is a bit of a UX issue, people dont expect what they typed in to suddenly change.

I've added this as a configuration option defaulting to the current behaviour so the next release isnt a breaking change. However It might make sense to change the default to "on" at some point. I think most people will want preserveInputFormat to be on.

Before, now with preserveInputFormat off (the default)
![preserve-off](https://user-images.githubusercontent.com/727013/28991986-b3024f78-79d4-11e7-9b6f-13241805d13c.gif)

Now, with preserveInputFormat on.
![preserve-on](https://user-images.githubusercontent.com/727013/28991992-c19fcb3c-79d4-11e7-8c82-a5b0fe824172.gif)
