### PR TITLE
Swap order of watchers to fix re initialisation issue.

### DIFF
--- a/src/scripts/controller.js
+++ b/src/scripts/controller.js
@@ -201,8 +201,8 @@ export default class AngularColorPickerController {
 
         // ngModel
 
-        this.$scope.$watch('AngularColorPickerController.ngModel', this.watchNgModel.bind(this));
         this.$scope.$watch('AngularColorPickerController.internalNgModel', this.watchNgModel.bind(this));
+        this.$scope.$watch('AngularColorPickerController.ngModel', this.watchNgModel.bind(this));
 
         // options
 


### PR DESCRIPTION
Hi, we have a strange bug where re initialisation shows the wrong color. Changing the order of these watchers fixes it.

See in the gif. After refreshing the page the swatch correctly shows the correct color. Then I click back and forth in our in page navigation the swatch is incorrectly showing black. The in page navigation is basically a ng-if, and our app is component style, lots of nested directives.

![color-picker-re-initalisation](https://user-images.githubusercontent.com/727013/29148577-a5b32b4a-7db1-11e7-93a9-6cf1396d58d5.gif)

I tried to create a unit test to show the problem, but was unable to reproduce the problem with a simple directive.
