### PR TITLE
call update function when close

### DIFF
--- a/src/scripts/controller.js
+++ b/src/scripts/controller.js
@@ -464,6 +464,7 @@ export default class AngularColorPickerController {
                 this.is_open = false;
                 this.$scope.$applyAsync();
 
+                this.update();
                 this.eventApiDispatch('onClose', [event]);
             }
         };


### PR DESCRIPTION
(to check and reformat value if wrong format value is inserted.)

we use with this options in our project
```
<color-picker options="{required: true, format:'hexString', restrictToFormat: false, alpha: false}" name="..." ng-model="..." required/>
```

if someone insert hex value directly (ex : ` FC11DE `) without using color-picker
the expected result is ` #FC11DE ` but hexString not be reformatted

I think update value when color-picker is closed is better