### PR TITLE
[ADD] dynamically update hue (or not) based on option

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-color-picker",
   "description": "Color Picker Directive For AngularJS",
-  "version": "3.4.7",
+  "version": "3.4.7-dynamicHue",
   "homepage": "https://github.com/ruhley/angular-color-picker",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "angularjs-color-picker",
   "description": "Color Picker Directive For AngularJS",
-  "version": "3.4.7",
+  "version": "3.4.7-dynamicHue",
   "license": "MIT",
   "main": "dist/angularjs-color-picker.min.js",
   "dependencies": {
     "angular": "^1.4.0",
+    "chromedriver": "^2.32.3",
     "tinycolor2": "^1.3.0"
   },
   "repository": "git://github.com/ruhley/angular-color-picker.git",

--- a/src/scripts/controller.js
+++ b/src/scripts/controller.js
@@ -656,6 +656,16 @@ export default class AngularColorPickerController {
         five_sixths.h = 300;
         six_sixths.h = 359;
 
+        if (!this.options.dynamicHue) {
+            zero_sixths.s = zero_sixths.v = '100%';
+            one_sixths.s = one_sixths.v = '100%';
+            two_sixths.s = two_sixths.v = '100%';
+            three_sixths.s = three_sixths.v = '100%';
+            four_sixths.s = four_sixths.v = '100%';
+            five_sixths.s = five_sixths.v = '100%';
+            six_sixths.s = six_sixths.v = '100%';
+        }
+
         el.css({
             'background': 'linear-gradient(to ' + direction + ', ' +
                 tinycolor(zero_sixths).toRgbString() + ' 0%, ' +

--- a/src/scripts/options-service.js
+++ b/src/scripts/options-service.js
@@ -19,6 +19,7 @@ export default class AngularColorPickerOptions {
             saturation: false,
             lightness: false,
             alpha: true,
+            dynamicHue: true,
             // picker
             round: false,
             pos: 'bottom left',

--- a/test/e2e/dynamicHue.js
+++ b/test/e2e/dynamicHue.js
@@ -1,0 +1,21 @@
+var Page = require('../page-object.js');
+
+describe('Options: ', () => {
+	describe('DynamicHue: ', () => {
+        beforeAll(() => {
+            Page.openPage();
+            Page.waitTillPageLoaded();
+        });
+
+        it('Should enable dynamic hue by default', () => {
+            Page.openColorPicker();
+            expect(Page.dynamicHue_field.getAttribute('value').toEqual(true));
+        });
+
+        it('Should allow dynamic hue to be turned off', () => {
+            Page.dynamicHue_field.$('[label="No"]').click();
+            Page.openColorPicker();
+            expect(Page.dynamicHue_field.getAttribute('value').toEqual(false));
+        });
+    });
+});

--- a/test/page-object.js
+++ b/test/page-object.js
@@ -21,6 +21,7 @@ class Page {
         this.saturation_field = element(by.model('options.saturation'));
         this.lightness_field = element(by.model('options.lightness'));
         this.alpha_field = element(by.model('options.alpha'));
+        this.dynamicHue_field = element(by.model('options.dynamicHue'));
 
         // swatch fields
         this.swatch_field = element(by.model('options.swatch'));

--- a/test/test.html
+++ b/test/test.html
@@ -60,6 +60,11 @@
                     <select ng-model="options.case" class="form-control" ng-options="option.value as option.label for option in caseOptions"></select>
                 </div>
 
+                <div class="row">
+                    <label class="control-label"Dynamic Hue (dynamicHue) - whether or not to allow hue control to change based on color selection</label>
+                    <select ng-model="options.dynamicHue" class="form-control" ng-options="option.value as option.label for option in boolOptions"></select>
+                </div>
+
                 <h3>Swatch</h3>
 
                 <div class="row">


### PR DESCRIPTION
New option dynamicHue (true, false). When true (default), hue selection bar is updated dynamically based on lightness/saturation levels in the main selection grid - already the behavior. When false, hue selection bar is displayed as if lightness and saturation were both 100%. This allows the user to select a very dark gray, for example, but still be able to see the available colors in the hue selector.