### PR TITLE
Update onBlur if the internalNgModel and ngModel do not match

### DIFF
--- a/src/scripts/controller.js
+++ b/src/scripts/controller.js
@@ -414,7 +414,7 @@ export default class AngularColorPickerController {
     }
 
     onBlur(event) {
-        if (this.internalNgModel !== this.onChangeValue) {
+        if (this.internalNgModel !== this.onChangeValue || this.internalNgModel !== this.ngModel) {
             this.updateModel = true;
             this.update();
         }


### PR DESCRIPTION
There is a bug where typing in the input box does not update the ngModel of the color-picker.
This happens when update() is called and updateModel is not set, the color-picker skips updating the ngModel. The result is that internalNgModel and ngModel are not matching. The color picker shows one color but the model is something else.

![screen shot 2018-11-30 at 9 00 03 am](https://user-images.githubusercontent.com/15931120/49293513-60aff100-f47e-11e8-8614-ce0da3e3a040.png)

My solution is to change the onBlur event to also call update() when the internalNgModel and ngModel do not match.
